### PR TITLE
wire in tiny ipc to encode params for messages

### DIFF
--- a/electron-server.js
+++ b/electron-server.js
@@ -255,6 +255,19 @@ app.on("ready", async () => {
     }
   });
 
+  ipcMain.handle("serialize-params", async (event, params) => {
+    try {
+      const encoded = FilecoinSigning.serializeParams(params);
+      return {
+        result: encoded,
+      };
+    } catch (e) {
+      return {
+        error: e.toString(),
+      };
+    }
+  });
+
   ipcMain.handle("signing-propose-multisig", async (event, msig, destination, signer, value) => {
     // TODO: this could just be done clientside if we could figure out how to import the library there
     const actor = await client.stateGetActor(signer, []);


### PR DESCRIPTION
So this is a really tiny PR that doesnt do much, but i wanted to put it up anyways to help illustrate what we need next in the send flow.

We can pass a javascript object containing message parameters to this and it will return us a Uint8Array of the cbor encoded params. For example, for the "RemoveSigner" method we could call on a multisig, we would pass the following object to the encode ipc:
```json
{
  "signer": "f019283",
  "decrease": true,
}
```

(parameter field names from: https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/multisig/multisig_actor.go#L328)